### PR TITLE
Feature/13 menu bar finetuning

### DIFF
--- a/components/MenuBar.vue
+++ b/components/MenuBar.vue
@@ -79,7 +79,7 @@
                 </ul>
             </div>
 
-            <div class="nav-item dropdown">
+            <div class="nav-item dropdown vv-window-selector">
                 <button
                     ref="windowListTogglerRef"
                     class="navbar-toggler vv-window-selector-toggler"
@@ -122,9 +122,11 @@
             order: 4;
         }
     }
+    .vv-window-selector {
+        order: 5;
+    }
     .vv-window-selector-toggler {
         display: inline-block !important;
-        order: 5;
     }
     .vv-window-selector-icon {
         background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 30 30'%3e%3crect stroke='rgba%28255, 255, 255, 0.55%29' stroke-width='2' fill='rgba%280,0,0,0.55%29' width='14' height='18' x='6' y='4'/%3e%3crect stroke='rgba%28255, 255, 255, 0.75%29' stroke-width='2' fill='white' width='14' height='18' x='10' y='9'/%3e%3c/svg%3e")

--- a/components/MenuBar.vue
+++ b/components/MenuBar.vue
@@ -6,10 +6,9 @@
     const AppDataStore = useAppDataStore()
     const menu = computed(() => AppDataStore.appMenu)
 
-    const isMenuOpen = ref(false)
     function ToggleMenuCollapse(e) {
         isWindowListOpen.value = false
-        isMenuOpen.value = !isMenuOpen.value
+        AppDataStore.isMobileMenuOpen = !AppDataStore.isMobileMenuOpen
     }
 
     const WMStore = useWMStore()
@@ -36,7 +35,7 @@
         windowListDropdown = new $bootstrap.Dropdown(windowListTogglerRef.value);
     })
     function ToggleWindowListCollapse(e) {
-        isMenuOpen.value = false
+        AppDataStore.isMobileMenuOpen = false
         windowListDropdown._isShown() ? windowListDropdown.show() : windowListDropdown.hide();
     }
 
@@ -63,7 +62,7 @@
 
             <div
                 class="navbar-collapse collapse vv-navbar-menu"
-                :class="{ show: isMenuOpen }"
+                :class="{ show: AppDataStore.isMobileMenuOpen }"
                 id="navbarMenu"
             >
                 <ul class="navbar-nav">

--- a/components/WindowManager.vue
+++ b/components/WindowManager.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 	import { computed } from 'vue'
+	import { useAppDataStore } from '~~/store/appData'
 	import { useWMStore, INewWindow, IWindow, IWindowType } from '~~/store/wm'
 	import { VicavWinBox } from "./VicavWinBox.client"
 
@@ -60,6 +61,11 @@
 		WMStore.RegisterWindowRef(i, ref)
 	}
 
+	const AppDataStore = useAppDataStore()
+	function OnFocus() {
+		AppDataStore.isMobileMenuOpen = false
+	}
+
 	function CloseWindow(windowIndex: number) {
 		WMStore.Close(windowIndex)
 	}
@@ -73,6 +79,7 @@
 			:key="i"
 			:options="window.winBoxOptions"
 			@open="RegisterWindowRef(i, $event)"
+			@focus="OnFocus"
 			@close="CloseWindow(i)"
 		>
 			<component

--- a/store/appData.ts
+++ b/store/appData.ts
@@ -50,9 +50,14 @@ export const useAppDataStore = defineStore(
 
 		GetProjectData()
 
+		const isMobileMenuOpen = ref(false);
+		const isMobile = ref(false);
+
 		return {
 			appTitle,
-			appMenu
+			appMenu,
+			isMobileMenuOpen,
+			isMobile,
 		}
 	}
 )


### PR DESCRIPTION
- created isMobileMenuOpen and isMobile flags in AppData store
- replaced the isMenuOpen in MenuBar with the store's isMobileMenuOpen
- hooked on winbox.js focus event in the WM to close the menu

Menu problem: open the menu on narrow screen, clicking on the topmost window in the WM does not trigger focus event, menu is not collapsed. => Will be dealt with in a separate task