### PR TITLE
build: remove git submodules, fetch openapi doc directly from github

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vicav-app-api"]
-	path = vicav-app-api
-	url = https://github.com/acdh-oeaw/vicav-app-api.git

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "npm": "9.x"
   },
   "scripts": {
-    "makeapi": "sta -p ./vicav-app-api/openapi.yaml -o ./gen/",
-    "build": "sta -p ./vicav-app-api/openapi.yaml -o ./gen/ && nuxt build",
+    "makeapi": "sta -p https://raw.githubusercontent.com/acdh-oeaw/vicav-app-api/master/openapi.json -o ./gen/",
+    "build": "sta -p https://raw.githubusercontent.com/acdh-oeaw/vicav-app-api/master/openapi.json -o ./gen/ && nuxt build",
     "start": "node .output/server/index.mjs",
     "dev": "nuxt dev",
     "generate": "nuxt generate",


### PR DESCRIPTION
this pr removes git submodules, which were only used to point to the openapi document, and instead fetches it directly from github.
