### PR TITLE
4 state of the application should be shareable via url

### DIFF
--- a/components/window-manager.client.vue
+++ b/components/window-manager.client.vue
@@ -1,11 +1,9 @@
 <script lang="ts" setup>
 import { debounce } from "@acdh-oeaw/lib";
-import type { LocationQueryRaw } from "vue-router";
 
 const windowsStore = useWindowsStore();
 const { arrangeWindows } = windowsStore;
 const { registry } = storeToRefs(windowsStore);
-const route = useRoute();
 
 const rootElement = ref<HTMLElement | null>(null);
 
@@ -13,34 +11,7 @@ const debouncedArrangeWindows = debounce(arrangeWindows, 150);
 
 useResizeObserver(rootElement, debouncedArrangeWindows);
 
-onMounted(async () => {
-	if (!route.query.w || !route.query.a) {
-		navigateEmpty();
-	}
-
-	// TODO validate with zod
-	let windowState = JSON.parse(route.query.w as string);
-	if (!Array.isArray(windowState)) {
-		navigateEmpty();
-	}
-
-	await nextTick();
-	windowState.forEach((w) => {
-		windowsStore.addWindow({
-			title: w.title,
-			kind: w.kind,
-			params: w.params,
-		});
-	});
-	windowsStore.setWindowArrangement(route.query.a as WindowArrangement);
-});
-
-function navigateEmpty() {
-	navigateTo({
-		path: "/",
-		query: { w: "[]", a: windowsStore.arrangement },
-	});
-}
+onMounted(windowsStore.restoreState);
 </script>
 
 <template>

--- a/components/window-manager.client.vue
+++ b/components/window-manager.client.vue
@@ -1,15 +1,46 @@
 <script lang="ts" setup>
 import { debounce } from "@acdh-oeaw/lib";
+import type { LocationQueryRaw } from "vue-router";
 
 const windowsStore = useWindowsStore();
 const { arrangeWindows } = windowsStore;
 const { registry } = storeToRefs(windowsStore);
+const route = useRoute();
 
 const rootElement = ref<HTMLElement | null>(null);
 
 const debouncedArrangeWindows = debounce(arrangeWindows, 150);
 
 useResizeObserver(rootElement, debouncedArrangeWindows);
+
+onMounted(async () => {
+	if (!route.query.w || !route.query.a) {
+		navigateEmpty();
+	}
+
+	// TODO validate with zod
+	let windowState = JSON.parse(route.query.w as string);
+	if (!Array.isArray(windowState)) {
+		navigateEmpty();
+	}
+
+	await nextTick();
+	windowState.forEach((w) => {
+		windowsStore.addWindow({
+			title: w.title,
+			kind: w.kind,
+			params: w.params,
+		});
+	});
+	windowsStore.setWindowArrangement(route.query.a as WindowArrangement);
+});
+
+function navigateEmpty() {
+	navigateTo({
+		path: "/",
+		query: { w: "[]", a: windowsStore.arrangement },
+	});
+}
 </script>
 
 <template>

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -126,10 +126,11 @@ export const useWindowsStore = defineStore("windows", () => {
 			await initializeScreen();
 			return;
 		}
+		const w = atob(route.query.w);
 
 		let windowStates: Array<WindowStateInferred>;
 		try {
-			windowStates = JSON.parse(route.query.w as string) as Array<WindowStateInferred>;
+			windowStates = JSON.parse(w) as Array<WindowStateInferred>;
 		} catch (e) {
 			toasts.addToast({
 				title: "RestoreState Error: JSON parse failed",
@@ -311,7 +312,7 @@ export const useWindowsStore = defineStore("windows", () => {
 		void navigateTo({
 			path: "/",
 			query: {
-				w: JSON.stringify(windowStates),
+				w: btoa(JSON.stringify(windowStates)),
 				a: arrangement.value,
 			},
 		});

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import type { QueryDescription } from "@/lib/api-client";
 import * as arrange from "@/utils/window-arrangement";
+
 import { useToastsStore } from "./use-toasts-store";
 
 interface WindowItemBase {
@@ -129,14 +130,18 @@ export const useWindowsStore = defineStore("windows", () => {
 		try {
 			windowStates = JSON.parse(route.query.w as string) as Array<WindowStateInferred>;
 		} catch (e) {
-			toasts.addToast({ title: "Error: JSON parse failed", description: e.message });
+			toasts.addToast({
+				title: "RestoreState Error: JSON parse failed",
+				description: e instanceof Error ? e.message : "Unknown error, check console",
+			});
+			console.error(e);
 			await initializeScreen();
 			return;
 		}
 
 		if (!Array.isArray(windowStates)) {
 			toasts.addToast({
-				title: "Error: Window list is not array",
+				title: "RestoreState Error: Window list is not array",
 				description: "Window list parameter must be an array",
 			});
 			await initializeScreen();
@@ -150,7 +155,7 @@ export const useWindowsStore = defineStore("windows", () => {
 				WindowState.parse(w);
 				addWindow({
 					title: w.title,
-					kind: w.kind,
+					kind: w.kind as WindowItemKind,
 					params: w.params,
 					x: w.x,
 					y: w.y,
@@ -158,7 +163,10 @@ export const useWindowsStore = defineStore("windows", () => {
 					width: w.width,
 				});
 			} catch (e) {
-				toasts.addToast({ title: "Error: WindowState parse failed", description: e.message });
+				toasts.addToast({
+					title: "RestoreState Error: WindowState parse failed",
+					description: e instanceof Error ? e.message : "Unknown error, check console",
+				});
 				console.error(e);
 			}
 		});

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -96,6 +96,7 @@ export type WindowArrangement = keyof typeof arrangements;
 const WindowState = z.object({
 	x: z.number(),
 	y: z.number(),
+	z: z.number(),
 	width: z.number(),
 	height: z.number(),
 	kind: z.string(),
@@ -158,6 +159,7 @@ export const useWindowsStore = defineStore("windows", () => {
 					params: w.params,
 					x: String(w.x) + "%",
 					y: String(w.y) + "%",
+					zIndex: w.z,
 					height: String(w.height) + "%",
 					width: String(w.width) + "%",
 				});
@@ -181,6 +183,7 @@ export const useWindowsStore = defineStore("windows", () => {
 		y?: number | string;
 		width?: number | string;
 		height?: number | string;
+		zIndex?: number;
 	}) {
 		const rootElement = document.getElementById(windowRootId);
 		if (rootElement == null) return;
@@ -201,10 +204,14 @@ export const useWindowsStore = defineStore("windows", () => {
 		const winbox = new WinBox({
 			id,
 			title,
+			index: params.zIndex ? params.zIndex : undefined,
 			x: params.x ? params.x : "center",
 			y: params.y ? params.y : "center",
 			width: params.width,
 			height: params.height,
+			onfocus() {
+				updateUrl();
+			},
 			onresize() {
 				updateUrl();
 			},
@@ -286,6 +293,7 @@ export const useWindowsStore = defineStore("windows", () => {
 			windowStates.push({
 				x: viewportPercentageWith2DigitPrecision(w.winbox.x as number, "width"),
 				y: viewportPercentageWith2DigitPrecision(w.winbox.y as number, "height"),
+				z: w.winbox.index,
 				width: viewportPercentageWith2DigitPrecision(w.winbox.width as number, "width"),
 				height: viewportPercentageWith2DigitPrecision(w.winbox.height as number, "height"),
 				kind: w.kind,

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -117,7 +117,7 @@ export const useWindowsStore = defineStore("windows", () => {
 	async function initializeScreen() {
 		await navigateTo({
 			path: "/",
-			query: { w: atob("[]"), a: arrangement.value },
+			query: { w: btoa("[]"), a: arrangement.value },
 		});
 	}
 

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -110,7 +110,7 @@ export const useWindowsStore = defineStore("windows", () => {
 	async function initializeScreen() {
 		await navigateTo({
 			path: "/",
-			query: { w: "[]", a: arrangement },
+			query: { w: "[]", a: arrangement.value },
 		});
 	}
 

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -101,6 +101,7 @@ const WindowState = z.object({
 	title: z.string(),
 	params: z.unknown(),
 });
+type WindowStateInferred = z.infer<typeof WindowState>;
 
 export const useWindowsStore = defineStore("windows", () => {
 	const registry = ref<WindowRegistry>(new Map());
@@ -124,9 +125,9 @@ export const useWindowsStore = defineStore("windows", () => {
 			return;
 		}
 
-		let windowStates: Array<WindowState>;
+		let windowStates: Array<WindowStateInferred>;
 		try {
-			windowStates = JSON.parse(route.query.w as string) as Array<WindowState>;
+			windowStates = JSON.parse(route.query.w as string) as Array<WindowStateInferred>;
 		} catch (e) {
 			toasts.addToast({ title: "Error: JSON parse failed", description: e.message });
 			await initializeScreen();
@@ -264,7 +265,7 @@ export const useWindowsStore = defineStore("windows", () => {
 	});
 
 	function serializeWindowStates() {
-		const windowStates: Array<WindowState> = [];
+		const windowStates: Array<WindowStateInferred> = [];
 		registry.value.forEach((w) => {
 			windowStates.push({
 				x: w.winbox.x as number,
@@ -274,7 +275,7 @@ export const useWindowsStore = defineStore("windows", () => {
 				kind: w.kind,
 				title: w.winbox.title,
 				params: w.params,
-			} as z.infer<typeof WindowState>);
+			} as WindowStateInferred);
 		});
 		console.log(JSON.stringify(windowStates));
 		return windowStates;

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import type { QueryDescription } from "@/lib/api-client";
 import * as arrange from "@/utils/window-arrangement";
+import { useToastsStore } from "./use-toasts-store";
 
 interface WindowItemBase {
 	id: string;
@@ -108,6 +109,8 @@ export const useWindowsStore = defineStore("windows", () => {
 	const router = useRouter();
 	const route = useRoute();
 
+	const toasts = useToastsStore();
+
 	async function initializeScreen() {
 		await navigateTo({
 			path: "/",
@@ -125,11 +128,16 @@ export const useWindowsStore = defineStore("windows", () => {
 		try {
 			windowStates = JSON.parse(route.query.w as string) as Array<WindowState>;
 		} catch (e) {
+			toasts.addToast({ title: "Error: JSON parse failed", description: e.message });
 			await initializeScreen();
 			return;
 		}
 
 		if (!Array.isArray(windowStates)) {
+			toasts.addToast({
+				title: "Error: Window list is not array",
+				description: "Window list parameter must be an array",
+			});
 			await initializeScreen();
 			return;
 		}
@@ -149,6 +157,7 @@ export const useWindowsStore = defineStore("windows", () => {
 					width: w.width,
 				});
 			} catch (e) {
+				toasts.addToast({ title: "Error: WindowState parse failed", description: e.message });
 				console.error(e);
 			}
 		});

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -107,22 +107,24 @@ export const useWindowsStore = defineStore("windows", () => {
 	const router = useRouter();
 	const route = useRoute();
 
-	function initializeScreen() {
-		navigateTo({
+	async function initializeScreen() {
+		await navigateTo({
 			path: "/",
-			query: { w: "[]", a: windowsStore.arrangement },
+			query: { w: "[]", a: arrangement },
 		});
 	}
 
 	const restoreState = async () => {
 		if (!route.query.w || !route.query.a) {
-			initializeScreen();
+			await initializeScreen();
+			return;
 		}
 
 		// TODO validate with zod
 		let windowState = JSON.parse(route.query.w as string);
 		if (!Array.isArray(windowState)) {
-			initializeScreen();
+			await initializeScreen();
+			return;
 		}
 
 		await nextTick();

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -149,7 +149,6 @@ export const useWindowsStore = defineStore("windows", () => {
 		}
 
 		await nextTick();
-		//TODO recalculate x/y/width/height according to current screen size
 		windowStates.forEach((w) => {
 			try {
 				WindowState.parse(w);
@@ -157,10 +156,10 @@ export const useWindowsStore = defineStore("windows", () => {
 					title: w.title,
 					kind: w.kind as WindowItemKind,
 					params: w.params,
-					x: w.x,
-					y: w.y,
-					height: w.height,
-					width: w.width,
+					x: String(w.x) + "%",
+					y: String(w.y) + "%",
+					height: String(w.height) + "%",
+					width: String(w.width) + "%",
 				});
 			} catch (e) {
 				toasts.addToast({
@@ -178,10 +177,10 @@ export const useWindowsStore = defineStore("windows", () => {
 		title: string;
 		kind: Kind;
 		params: WindowItemMap[Kind]["params"];
-		x?: number;
-		y?: number;
-		width?: number;
-		height?: number;
+		x?: number | string; // string support added for "px" and "%" typed values
+		y?: number | string;
+		width?: number | string;
+		height?: number | string;
 	}) {
 		const rootElement = document.getElementById(windowRootId);
 		if (rootElement == null) return;
@@ -274,12 +273,21 @@ export const useWindowsStore = defineStore("windows", () => {
 
 	function serializeWindowStates() {
 		const windowStates: Array<WindowStateInferred> = [];
+
+		const rootElement = document.getElementById(windowRootId);
+		if (rootElement == null) return;
+		const viewport = rootElement.getBoundingClientRect();
+
+		function viewportPercentageWith2DigitPrecision(x: number, dir: "height" | "width") {
+			return Math.floor((10000 * x) / viewport[dir]) / 100;
+		}
+
 		registry.value.forEach((w) => {
 			windowStates.push({
-				x: w.winbox.x as number,
-				y: w.winbox.y as number,
-				width: w.winbox.width as number,
-				height: w.winbox.height as number,
+				x: viewportPercentageWith2DigitPrecision(w.winbox.x as number, "width"),
+				y: viewportPercentageWith2DigitPrecision(w.winbox.y as number, "height"),
+				width: viewportPercentageWith2DigitPrecision(w.winbox.width as number, "width"),
+				height: viewportPercentageWith2DigitPrecision(w.winbox.height as number, "height"),
 				kind: w.kind,
 				title: w.winbox.title,
 				params: w.params,

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -130,11 +130,16 @@ export const useWindowsStore = defineStore("windows", () => {
 		}
 
 		await nextTick();
+		//TODO recalculate x/y/width/height according to current screen size
 		windowState.forEach((w) => {
 			addWindow({
 				title: w.title,
 				kind: w.kind,
 				params: w.params,
+				x: w.x,
+				y: w.y,
+				height: w.height,
+				width: w.width,
 			});
 		});
 		setWindowArrangement(route.query.a as WindowArrangement);
@@ -145,6 +150,10 @@ export const useWindowsStore = defineStore("windows", () => {
 		title: string;
 		kind: Kind;
 		params: WindowItemMap[Kind]["params"];
+		x?: number;
+		y?: number;
+		width?: number;
+		height?: number;
 	}) {
 		const rootElement = document.getElementById(windowRootId);
 		if (rootElement == null) return;
@@ -165,8 +174,10 @@ export const useWindowsStore = defineStore("windows", () => {
 		const winbox = new WinBox({
 			id,
 			title,
-			x: "center",
-			y: "center",
+			x: params.x ? params.x : "center",
+			y: params.y ? params.y : "center",
+			width: params.width,
+			height: params.height,
 			onresize() {
 				updateUrl();
 			},

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -4,11 +4,6 @@ import WinBox from "winbox";
 import type { QueryDescription } from "@/lib/api-client";
 import * as arrange from "@/utils/window-arrangement";
 
-interface WindowState {
-	x: number;
-	y: number;
-}
-
 interface WindowItemBase {
 	id: string;
 	winbox: WinBox;
@@ -96,6 +91,16 @@ export const arrangements = {
 
 export type WindowArrangement = keyof typeof arrangements;
 
+interface WindowState {
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+	kind: WindowItemKind;
+	title: string;
+	params: unknown;
+}
+
 export const useWindowsStore = defineStore("windows", () => {
 	const registry = ref<WindowRegistry>(new Map());
 	const arrangement = ref<WindowArrangement>("smart-tile");
@@ -142,17 +147,6 @@ export const useWindowsStore = defineStore("windows", () => {
 			},
 			root: rootElement,
 		});
-
-		const windowState = {
-			x: winbox.x as number,
-			y: winbox.y as number,
-			focus: winbox.focus as boolean,
-			width: winbox.width as number,
-			height: winbox.height as number,
-			fullscreen: winbox.fullscreen as boolean,
-			minimized: winbox.minimized as boolean,
-			maximized: winbox.maximized as boolean,
-		};
 
 		registry.value.set(id, {
 			id,
@@ -209,7 +203,7 @@ export const useWindowsStore = defineStore("windows", () => {
 	});
 
 	function serializeWindowStates() {
-		let windowStates = [];
+		let windowStates: Array<WindowState> = [];
 		registry.value.forEach((w, id) => {
 			windowStates.push({
 				x: w.winbox.x,
@@ -219,7 +213,7 @@ export const useWindowsStore = defineStore("windows", () => {
 				kind: w.kind,
 				title: w.winbox.title,
 				params: w.params,
-			});
+			} as WindowState);
 		});
 		console.log(JSON.stringify(windowStates));
 		return windowStates;

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -117,7 +117,7 @@ export const useWindowsStore = defineStore("windows", () => {
 	async function initializeScreen() {
 		await navigateTo({
 			path: "/",
-			query: { w: "[]", a: arrangement.value },
+			query: { w: atob("[]"), a: arrangement.value },
 		});
 	}
 

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -221,7 +221,7 @@ export const useWindowsStore = defineStore("windows", () => {
 
 	function updateUrl() {
 		let windowStates = serializeWindowStates();
-		// TODO: check url length, it may be too long
+		// TODO: check url length, it may be too long. Note: shortest limit is 2047 (MS Edge) https://serpstat.com/blog/how-long-should-be-the-page-url-length-for-seo/
 		navigateTo({
 			path: "/",
 			query: {

--- a/stores/use-windows-store.ts
+++ b/stores/use-windows-store.ts
@@ -121,7 +121,9 @@ export const useWindowsStore = defineStore("windows", () => {
 		}
 
 		// TODO validate with zod
-		let windowState = JSON.parse(route.query.w as string);
+		const windowState: Array<WindowState> = JSON.parse(
+			route.query.w as string,
+		) as Array<WindowState>;
 		if (!Array.isArray(windowState)) {
 			await initializeScreen();
 			return;
@@ -165,11 +167,11 @@ export const useWindowsStore = defineStore("windows", () => {
 			title,
 			x: "center",
 			y: "center",
-			onresize(width, height) {
-				serializeWindowStates();
+			onresize() {
+				updateUrl();
 			},
-			onmove(x, y) {
-				serializeWindowStates();
+			onmove() {
+				updateUrl();
 			},
 			onclose() {
 				registry.value.delete(id);
@@ -232,13 +234,13 @@ export const useWindowsStore = defineStore("windows", () => {
 	});
 
 	function serializeWindowStates() {
-		let windowStates: Array<WindowState> = [];
-		registry.value.forEach((w, id) => {
+		const windowStates: Array<WindowState> = [];
+		registry.value.forEach((w) => {
 			windowStates.push({
-				x: w.winbox.x,
-				y: w.winbox.y,
-				width: w.winbox.width,
-				height: w.winbox.height,
+				x: w.winbox.x as number,
+				y: w.winbox.y as number,
+				width: w.winbox.width as number,
+				height: w.winbox.height as number,
 				kind: w.kind,
 				title: w.winbox.title,
 				params: w.params,
@@ -249,9 +251,9 @@ export const useWindowsStore = defineStore("windows", () => {
 	}
 
 	function updateUrl() {
-		let windowStates = serializeWindowStates();
+		const windowStates = serializeWindowStates();
 		// TODO: check url length, it may be too long. Note: shortest limit is 2047 (MS Edge) https://serpstat.com/blog/how-long-should-be-the-page-url-length-for-seo/
-		navigateTo({
+		void navigateTo({
 			path: "/",
 			query: {
 				w: JSON.stringify(windowStates),


### PR DESCRIPTION
- url is updated by window opening, closing, moving, resizing, and focusing
- url is parsed and the state of windows is recovered
- window sizes and positions are encoded as viewport percentage
  - extended `addWindow` method in window store with initial size and position parameters
- show toast messages on errors
- window state is bas64 encoded in url