### PR TITLE
fix: avoid serverside fetch errors

### DIFF
--- a/components/app-header.vue
+++ b/components/app-header.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { isNonEmptyString } from "@acdh-oeaw/lib";
+import { isNonEmptyString, noop } from "@acdh-oeaw/lib";
 
 import type { ItemType } from "@/lib/api-client";
 
@@ -7,7 +7,13 @@ const windowsStore = useWindowsStore();
 const { addWindow } = windowsStore;
 
 const { data, suspense } = useProjectInfo();
-await suspense();
+onServerPrefetch(async () => {
+	/**
+	 * @see https://github.com/TanStack/query/issues/6606
+	 * @see https://github.com/TanStack/query/issues/5976
+	 */
+	await suspense().catch(noop);
+});
 
 const menus = computed(() => {
 	return data.value?.projectConfig?.menu?.main ?? [];

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -1,5 +1,5 @@
 <script lang="ts" setup>
-import { isNonEmptyString } from "@acdh-oeaw/lib";
+import { isNonEmptyString, noop } from "@acdh-oeaw/lib";
 import { ColorSpace, getLuminance, HSL, parse, sRGB, to as convert } from "colorjs.io/fn";
 import type { WebSite, WithContext } from "schema-dts";
 
@@ -10,7 +10,13 @@ const env = useRuntimeConfig();
 const route = useRoute();
 
 const { data, suspense } = useProjectInfo();
-await suspense();
+onServerPrefetch(async () => {
+	/**
+	 * @see https://github.com/TanStack/query/issues/6606
+	 * @see https://github.com/TanStack/query/issues/5976
+	 */
+	await suspense().catch(noop);
+});
 
 const siteTitle = computed(() => {
 	return data.value?.projectConfig?.title ?? "VICAV3.0 - Vienna Corpus of Arabic Varieties";

--- a/plugins/query-client.ts
+++ b/plugins/query-client.ts
@@ -31,12 +31,16 @@ export default defineNuxtPlugin((nuxt) => {
 						  (error.error?.title as string | undefined) ?? error.statusText
 						: error.message;
 
-				addToast({
-					title: "Error",
-					description: message,
-					type: "foreground",
-					variant: "negative",
-				});
+				if (process.client) {
+					addToast({
+						title: "Error",
+						description: message,
+						type: "foreground",
+						variant: "negative",
+					});
+				} else {
+					console.error(error);
+				}
 			},
 		}),
 	});


### PR DESCRIPTION
this catches any errors from network requests while pre-rendering serverside (which would redirect to error page with 500 status code), and delegates error handling to the client, i.e. vue-query's global error handler, which will show a toast notification.

x-ref #103