### PR TITLE
Search in "romanized" values for word tags select widget

### DIFF
--- a/components/explore-samples-form-window-content.vue
+++ b/components/explore-samples-form-window-content.vue
@@ -75,7 +75,6 @@ countries.forEach((country) => {
 });
 
 const placeOptions = options;
-
 const uniqueFilter = function (value: unknown, index: number, array: Array<unknown>) {
 	return array.indexOf(value) === index;
 };

--- a/components/explore-samples-form-window-content.vue
+++ b/components/explore-samples-form-window-content.vue
@@ -7,6 +7,7 @@ import {
 	TagsInputItemText,
 	TagsInputRoot,
 } from "radix-vue";
+import { transliterate as tr } from "transliteration";
 
 import dataTypes from "@/config/dataTypes";
 import type { ExploreSamplesFormWindowItem, GeoMapWindowItem, WindowItem } from "@/types/global.d";
@@ -92,6 +93,14 @@ const wordOptions = computed(() => {
 		return { label: item, value: item };
 	});
 });
+
+const wordFilter = function (list: Array<string>, searchTerm: string) {
+	const translitTerm = tr(searchTerm);
+
+	return list.filter((item) => {
+		return tr(item).indexOf(translitTerm) !== -1;
+	});
+};
 
 const sex = ref(["m", "f"]);
 
@@ -238,6 +247,7 @@ const openSearchResultsWindow = function () {
 				<TagsSelect
 					v-if="wordOptions"
 					v-model="words"
+					:filter-function="wordFilter"
 					:options="wordOptions"
 					:placeholder="`Search for words...`"
 				/>

--- a/components/ui/tags-select.vue
+++ b/components/ui/tags-select.vue
@@ -26,7 +26,7 @@ interface Tag {
 interface Props {
 	options: Array<Tag>;
 	placeholder: string;
-	filterFunction?: (list: Array<string>, searchTerm: string) => Array<Tag>;
+	filterFunction?: (list: Array<string>, searchTerm: string) => Array<string>;
 }
 
 const props = defineProps<Props>();
@@ -38,7 +38,7 @@ const filter = computed(() => {
 	return (
 		filterFunction.value ??
 		function (list: Array<string>, searchTerm: string) {
-			list.filter((value) => value === searchTerm);
+			return list.filter((value) => value === searchTerm);
 		}
 	);
 });
@@ -75,7 +75,11 @@ watch(
 					:value="item"
 				>
 					<TagsInputItemText class="text-sm">
-						{{ options.find((opt) => opt.value === item)!.label }}
+						{{
+							options?.find((opt) => opt.value === item)
+								? options?.find((opt) => opt.value === item)!.label
+								: item
+						}}
 					</TagsInputItemText>
 					<TagsInputItemDelete>
 						<Icon icon="lucide:x" />
@@ -86,7 +90,6 @@ watch(
 					<TagsInputInput
 						class="flex flex-1 flex-wrap items-center gap-2 rounded !bg-transparent px-1 focus:outline-none"
 						:placeholder="placeholder"
-						@keydown.enter.prevent
 					/>
 				</ComboboxInput>
 			</TagsInputRoot>
@@ -98,6 +101,18 @@ watch(
 				<ComboboxEmpty class="py-2 text-center text-xs font-medium text-gray-400" />
 
 				<ComboboxGroup>
+					<ComboboxItem
+						v-if="searchTerm"
+						:key="searchTerm"
+						class="relative flex h-[25px] select-none items-center rounded-[3px] pl-[25px] pr-[35px] text-[13px] leading-none data-[disabled]:pointer-events-none data-[highlighted]:bg-secondary data-[disabled]:text-gray-300 data-[highlighted]:outline-none"
+						:value="searchTerm"
+						><ComboboxItemIndicator
+							class="absolute left-0 inline-flex w-[25px] items-center justify-center"
+						>
+							<Icon icon="radix-icons:check" />
+						</ComboboxItemIndicator>
+						<span>{{ searchTerm }} </span>
+					</ComboboxItem>
 					<ComboboxItem
 						v-for="(option, index) in options"
 						:key="index"

--- a/components/ui/tags-select.vue
+++ b/components/ui/tags-select.vue
@@ -26,14 +26,22 @@ interface Tag {
 interface Props {
 	options: Array<Tag>;
 	placeholder: string;
+	filterFunction?: (list: Array<string>, searchTerm: string) => Array<Tag>;
 }
 
 const props = defineProps<Props>();
-const { options, placeholder } = toRefs(props);
+const { options, placeholder, filterFunction } = toRefs(props);
 const searchTerm = ref("");
 const model = defineModel<Array<string>>();
 const open = ref(false);
-
+const filter = computed(() => {
+	return (
+		filterFunction.value ??
+		function (list: Array<string>, searchTerm: string) {
+			list.filter((value) => value === searchTerm);
+		}
+	);
+});
 watch(
 	model,
 	() => {
@@ -50,6 +58,7 @@ watch(
 		v-model:open="open"
 		v-model:search-term="searchTerm"
 		class="mx-auto w-full"
+		:filter-function="filter"
 		multiple
 	>
 		<ComboboxAnchor class="w-full">

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
 		"pino": "^9.2.0",
 		"radix-vue": "^1.8.3",
 		"swagger-typescript-api": "^13.0.3",
+		"transliteration": "^2.3.5",
 		"ts-error": "^1.0.6",
 		"tw-elements": "^2.0.0",
 		"v3-infinite-loading": "^1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,6 +103,9 @@ importers:
       swagger-typescript-api:
         specifier: ^13.0.3
         version: 13.0.22
+      transliteration:
+        specifier: ^2.3.5
+        version: 2.3.5
       ts-error:
         specifier: ^1.0.6
         version: 1.0.6
@@ -4831,6 +4834,11 @@ packages:
 
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  transliteration@2.3.5:
+    resolution: {integrity: sha512-HAGI4Lq4Q9dZ3Utu2phaWgtm3vB6PkLUFqWAScg/UW+1eZ/Tg6Exo4oC0/3VUol/w4BlefLhUUSVBr/9/ZGQOw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
 
   ts-api-utils@1.3.0:
     resolution: {integrity: sha512-UQMIo7pb8WRomKR1/+MFVLTroIvDVtMX3K6OUir8ynLyzB8Jeriont2bTAtmNPa1ekAgN7YPDyf6V+ygrdU+eQ==}
@@ -10447,6 +10455,10 @@ snapshots:
   totalist@3.0.1: {}
 
   tr46@0.0.3: {}
+
+  transliteration@2.3.5:
+    dependencies:
+      yargs: 17.7.2
 
   ts-api-utils@1.3.0(typescript@5.6.2):
     dependencies:


### PR DESCRIPTION
Part of #167 

* Add option to include filter function in tegs-select widget
* Add word filter function which compares romanized versions of the words, ie. devoid of accents and special characters. Eg. if you type "tal" in the search widget, then you would also get word options containing "ṭāl"