### PR TITLE
Fix #167 Multiple speakers, Autocomplete on backend + layout

### DIFF
--- a/components/corpus-query-window-content.vue
+++ b/components/corpus-query-window-content.vue
@@ -94,6 +94,7 @@ const words: Ref<Array<string>> = ref([]);
 				</span>
 			</div>
 			<InputExtended
+				v-if="specialCharacters"
 				id="query"
 				v-model="queryString"
 				aria-label="Search"

--- a/components/corpus-query-window-content.vue
+++ b/components/corpus-query-window-content.vue
@@ -59,9 +59,16 @@ const words: Ref<Array<string>> = ref([]);
 	<!-- eslint-disable vue/no-v-html -->
 	<div class="p-2">
 		<form
-			class="block w-full rounded border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
+			class="block w-full rounded border border-gray-300 bg-gray-50 p-2.5 px-4 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
 		>
-			<label class="font-bold" for="word_tags">Search for words</label>
+			<label class="mb-2 flex !w-40 p-0 font-bold" for="word_tags">
+				<span class="grow">Search for words</span>
+			</label>
+			<div class="flex items-center gap-2">
+				<Info class="size-4" /><span class="text-gray-500"
+					>Enter non-accented Latin characters and select word options from the list</span
+				>
+			</div>
 			<TagsSelect
 				v-if="wordOptions"
 				id="word_tags"
@@ -71,19 +78,22 @@ const words: Ref<Array<string>> = ref([]);
 				:options="wordOptions"
 				:placeholder="`Search for words...`"
 			/>
-			<label class="flex !w-40 font-bold" for="query"
-				><span class="grow">Advanced search</span>
-				<a
-					class="content-center"
-					href="https://howto.acdh.oeaw.ac.at/de/resources/corpus-query-language-im-austrian-media-corpus"
-					target="_blank"
-					title="More information about CQL syntax"
-					><Info class="size-4" /><span class="hidden">More information about CQL Syntax</span></a
-				>
-			</label>
 
+			<label class="mb-2 flex !w-40 p-0 font-bold" for="word_tags">
+				<span class="grow">Advanced search</span>
+			</label>
+			<div class="mb-2 flex items-center gap-2">
+				<Info class="size-4" /><span class="text-gray-500"
+					>Enter exact words within a CQL query. (<a
+						class="content-center"
+						href="https://howto.acdh.oeaw.ac.at/de/resources/corpus-query-language-im-austrian-media-corpus"
+						target="_blank"
+						title="More information about CQL syntax"
+						><span>More info</span></a
+					>)
+				</span>
+			</div>
 			<InputExtended
-				v-if="specialCharacters"
 				id="query"
 				v-model="queryString"
 				aria-label="Search"

--- a/components/corpus-query-window-content.vue
+++ b/components/corpus-query-window-content.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import { Info } from "lucide-vue-next";
+
 import type { CorpusSearchHits } from "@/lib/api-client";
 import type { CorpusQuerySchema } from "@/types/global";
 
@@ -9,6 +11,10 @@ const queryString = ref(props.params.queryString);
 const hits = ref<Array<CorpusSearchHits & { label?: string }> | undefined>([]);
 
 async function searchCorpus() {
+	if (words.value.length > 0)
+		queryString.value =
+			'[word="' + words.value.map((w) => w.replace("*", ".*").replace("?", ".")).join("|") + '"]';
+
 	const result = await api.vicav.searchCorpus(
 		{ query: queryString.value },
 		{ headers: { Accept: "application/json" } },
@@ -29,6 +35,24 @@ const openNewWindowFromAnchor = useAnchorClickHandler();
 
 const { data: config } = useProjectInfo();
 const specialCharacters = config.value?.projectConfig?.specialCharacters;
+const wordSearch = ref("");
+const dataWordsQuery = useDataWords(
+	{ dataType: "CorpusText", query: wordSearch },
+	{ enabled: false },
+);
+
+watch(wordSearch, async (value) => {
+	if (!value || value.length < 2) return;
+	await dataWordsQuery.refetch();
+});
+
+const wordOptions = computed(() => {
+	return ((dataWordsQuery.data.value as unknown as Array<string>) ?? []).map((item: string) => {
+		return { label: item, value: item };
+	});
+});
+
+const words: Ref<Array<string>> = ref([]);
 </script>
 
 <template>
@@ -37,8 +61,30 @@ const specialCharacters = config.value?.projectConfig?.specialCharacters;
 		<form
 			class="block w-full rounded border border-gray-300 bg-gray-50 p-2.5 text-sm text-gray-900 focus:border-blue-500 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white dark:placeholder:text-gray-400 dark:focus:border-blue-500 dark:focus:ring-blue-500"
 		>
+			<label class="font-bold" for="word_tags">Search for words</label>
+			<TagsSelect
+				v-if="wordOptions"
+				id="word_tags"
+				v-model="words"
+				v-model:search-term="wordSearch"
+				:filter-function="(i) => i"
+				:options="wordOptions"
+				:placeholder="`Search for words...`"
+			/>
+			<label class="flex !w-40 font-bold" for="query"
+				><span class="grow">Advanced search</span>
+				<a
+					class="content-center"
+					href="https://howto.acdh.oeaw.ac.at/de/resources/corpus-query-language-im-austrian-media-corpus"
+					target="_blank"
+					title="More information about CQL syntax"
+					><Info class="size-4" /><span class="hidden">More information about CQL Syntax</span></a
+				>
+			</label>
+
 			<InputExtended
 				v-if="specialCharacters"
+				id="query"
 				v-model="queryString"
 				aria-label="Search"
 				placeholder="Search in corpus ..."
@@ -47,7 +93,7 @@ const specialCharacters = config.value?.projectConfig?.specialCharacters;
 			/>
 			<button
 				class="inline-block h-10 w-full whitespace-nowrap rounded border-2 border-solid border-primary bg-on-primary text-center align-middle font-bold text-primary hover:bg-primary hover:text-on-primary disabled:border-gray-400 disabled:text-gray-400 hover:disabled:bg-on-primary hover:disabled:text-gray-400"
-				:disabled="queryString === ''"
+				:disabled="queryString === '' && words.length == 0"
 				@click.prevent.stop="searchCorpus"
 			>
 				Query

--- a/components/corpus-text-window-content.vue
+++ b/components/corpus-text-window-content.vue
@@ -110,10 +110,12 @@ onMounted(async () => {
 					<td>{{ teiHeader?.resp }}</td>
 				</tr>
 				<tr>
-					<th>Speaker:</th>
+					<th>Speakers:</th>
 					<td>
-						{{ teiHeader?.person.name }} (age: {{ teiHeader?.person.age }}, sex:
-						{{ teiHeader?.person.sex }})
+						<span v-for="(person, index) in teiHeader?.person" :key="index">
+							{{ person.name }} (age: {{ person.age }}, sex: {{ person.sex }})
+							<span v-if="index < (teiHeader?.person.length || 1) - 1">, </span>
+						</span>
 					</td>
 				</tr>
 			</tbody>

--- a/components/data-list-window-content.vue
+++ b/components/data-list-window-content.vue
@@ -52,13 +52,17 @@ const debugString = debug ? JSON.stringify(groupedItems, null, 2) : "";
 			</h2>
 			<h2 v-else-if="Object.keys(groupedItems).length > 1" class="text-lg">Unspecified country</h2>
 			<div v-for="(itemsByPlace, region) in itemsByRegion" :key="region" class="p-2 text-base">
-				<h4 v-if="region !== ''" class="text-lg italic">{{ region }}</h4>
+				<h4 v-if="region !== ''" class="text-lg italic">
+					{{ region }}
+					<span>({{ Object.values(itemsByPlace).flat(2).length }})</span>
+				</h4>
 				<h4 v-else-if="Object.keys(itemsByRegion).length > 1" class="text-lg italic">
 					Unspecified region
 				</h4>
 				<div v-for="(itemsBydataType, place) in itemsByPlace" :key="place" class="p-2">
 					<h5 v-if="place !== ''" class="text-base font-bold">
 						{{ place.replace(/^zzz_/, "") }}
+						<span>({{ Object.values(itemsBydataType).flat().length }})</span>
 					</h5>
 					<h5 v-else class="text-base font-bold">Unspecified place</h5>
 					<div v-for="(items, dataType) in itemsBydataType as groupedByDataType" :key="dataType">

--- a/components/data-list-window-content.vue
+++ b/components/data-list-window-content.vue
@@ -1,5 +1,7 @@
 <!-- eslint-disable @typescript-eslint/sort-type-constituents -->
 <script lang="ts" setup>
+import type { JsonObject } from "type-fest";
+
 import type { DataListWindowItem, DataTypesEnum } from "@/types/global.d";
 import type { simpleTEIMetadata } from "@/types/teiCorpus.d";
 
@@ -25,7 +27,16 @@ const groupedItems = getGroupedItems(
 	["place.country", "place.region", "place.settlement", "dataType"],
 	"dataType",
 	props.params.dataTypes,
-	"label",
+	(a: JsonObject, b: JsonObject) => {
+		const amatch = Number((a as simpleTEIMetadata).label?.match(/[a-z]+(\d+)/i)?.at(1));
+		const bmatch = Number((b as simpleTEIMetadata).label?.match(/[a-z]+(\d+)/i)?.at(1));
+
+		if (!amatch || !bmatch)
+			return !a.label || !b.label ? 0 : a.label < b.label ? -1 : a.label > b.label ? 1 : 0;
+		else {
+			return amatch < bmatch ? -1 : amatch > bmatch ? 1 : 0;
+		}
+	},
 	props.params.filterListBy,
 ) as groupedByCountry;
 const openNewWindowFromAnchor = useAnchorClickHandler();
@@ -54,7 +65,9 @@ const debugString = debug ? JSON.stringify(groupedItems, null, 2) : "";
 			<div v-for="(itemsByPlace, region) in itemsByRegion" :key="region" class="p-2 text-base">
 				<h4 v-if="region !== ''" class="text-lg italic">
 					{{ region }}
-					<span>({{ Object.values(itemsByPlace).flat(2).length }})</span>
+					<span v-if="Object.values(itemsByPlace).flat(2).length > 1"
+						>({{ Object.values(itemsByPlace).flat(2).length }})</span
+					>
 				</h4>
 				<h4 v-else-if="Object.keys(itemsByRegion).length > 1" class="text-lg italic">
 					Unspecified region
@@ -62,7 +75,6 @@ const debugString = debug ? JSON.stringify(groupedItems, null, 2) : "";
 				<div v-for="(itemsBydataType, place) in itemsByPlace" :key="place" class="p-2">
 					<h5 v-if="place !== ''" class="text-base font-bold">
 						{{ place.replace(/^zzz_/, "") }}
-						<span>({{ Object.values(itemsBydataType).flat().length }})</span>
 					</h5>
 					<h5 v-else class="text-base font-bold">Unspecified place</h5>
 					<div v-for="(items, dataType) in itemsBydataType as groupedByDataType" :key="dataType">

--- a/components/data-table-window-content.vue
+++ b/components/data-table-window-content.vue
@@ -26,13 +26,13 @@ const items = computed(() => {
 });
 
 const columns = ref([
-	columnHelper.accessor((row) => row.person.name, {
+	columnHelper.accessor((row) => row.person.at(0)?.name, {
 		id: "label",
 		cell: (info) => {
 			const identifier =
 				info.getValue() +
-				(info.row.original.person.sex ? `/${info.row.original.person.sex}` : "") +
-				(info.row.original.person.age ? `/${info.row.original.person.age}` : "");
+				(info.row.original.person.at(0)?.sex ? `/${info.row.original.person.at(0)?.sex}` : "") +
+				(info.row.original.person.at(0)?.age ? `/${info.row.original.person.at(0)?.age}` : "");
 			let linked_id: string | undefined = undefined;
 			let linked_type: string | undefined = undefined;
 			if (info.row.original.secondaryDataType === "Sample Text") {
@@ -43,7 +43,10 @@ const columns = ref([
 
 			if (linked_type) {
 				linked_id = simpleItems.value.find((i) => {
-					return i.dataType === linked_type && i.person.name === info.row.original.person.name;
+					return (
+						i.dataType === linked_type &&
+						i.person.at(0)?.name === info.row.original.person.at(0)?.name
+					);
 				})?.id;
 			}
 			return linked_id
@@ -61,20 +64,20 @@ const columns = ref([
 		header: "Name",
 		footer: (props) => props.column.id,
 	}),
-	columnHelper.accessor((row) => row.person.name, {
+	columnHelper.accessor((row) => row.person.at(0)?.name, {
 		id: "name",
 		cell: (info) => info.getValue(),
 		header: "Name",
 		footer: (props) => props.column.id,
 	}),
-	columnHelper.accessor((row) => row.person.age, {
+	columnHelper.accessor((row) => row.person.at(0)?.age, {
 		id: "age",
 		cell: (info) => info.getValue(),
 		header: "Age",
 		footer: (props) => props.column.id,
 		filterFn: "inNumberRange",
 	}),
-	columnHelper.accessor((row) => row.person.sex, {
+	columnHelper.accessor((row) => row.person.at(0)?.sex, {
 		id: "sex",
 		cell: (info) => info.getValue(),
 		header: "Sex",
@@ -139,8 +142,9 @@ const setFilters = function (value: ColumnFiltersState) {
 <template>
 	<div v-if="simpleItems">
 		<div class="flex flex-wrap justify-between py-2">
-			<DataTableFilterTeiHeaders v-if="tables" :filters="columnFilters" :table="tables" />
+			<DataTableFilterTeiHeaders v-if="tables" :filters="columnFilters" rows="" :table="tables" />
 			<DataTablePagination v-if="tables" :table="tables as unknown as Table<never>" />
+			<div>{{ tables?.getFilteredRowModel().rows.length }} results</div>
 		</div>
 		<DataTable
 			:columns="columns as Array<ColumnDef<never>>"

--- a/components/explore-samples-form-window-content.vue
+++ b/components/explore-samples-form-window-content.vue
@@ -235,6 +235,27 @@ const openSearchResultsWindow = function () {
 		}, 1000);
 	}
 };
+
+/**
+ * Open search results in new window.
+ */
+const openSearchResultsNewWindow = function () {
+	addWindow({
+		targetType: "ExploreSamples",
+		params: resultWindowParams.value,
+		title: `Search results for ${[words.value.join(","), places.value.join(",")].join(", ")}`,
+	} as WindowState)!;
+	addWindow({
+		targetType: "WMap",
+		params: {
+			title: "Search results",
+			queryString: "",
+			endpoint: "compare_markers",
+			queryParams: queryParams.value,
+		},
+		title: `${params.value.dataTypes[0]}s for ${[words.value.join(","), places.value.join(",")].join(", ")}`,
+	} as WindowState)!;
+};
 </script>
 
 <template>
@@ -320,7 +341,7 @@ const openSearchResultsWindow = function () {
 				</TagsInputRoot>
 			</div>
 
-			<div class="flex flex-row gap-2.5">
+			<div v-if="params.dataTypes.includes('Feature')" class="flex flex-row gap-2.5">
 				<label for="translation">Translation</label>
 				<input
 					id="translation"
@@ -357,7 +378,22 @@ const openSearchResultsWindow = function () {
 			>
 				Query
 			</button>
-			<br />
+
+			<button
+				class="inline-block h-10 w-full whitespace-nowrap rounded border-2 border-solid border-primary bg-on-primary text-center align-middle font-bold text-primary hover:bg-primary hover:text-on-primary disabled:border-gray-400 disabled:text-gray-400 hover:disabled:bg-on-primary hover:disabled:text-gray-400"
+				:disabled="
+					words.length === 0 &&
+					translation == '' &&
+					comment == '' &&
+					places.length === 0 &&
+					persons.length === 0 &&
+					features.length === 0 &&
+					sentences.length === 0
+				"
+				@click.prevent.stop="openSearchResultsNewWindow"
+			>
+				Search in new window
+			</button>
 		</form>
 	</div>
 </template>

--- a/components/explore-samples-form-window-content.vue
+++ b/components/explore-samples-form-window-content.vue
@@ -95,7 +95,8 @@ const uniqueFilter = function (value: unknown, index: number, array: Array<unkno
 	return array.indexOf(value) === index;
 };
 const personOptions = dataset
-	.map((item) => item.person.name)
+	.map((item) => item.person.map((i) => i.name))
+	.flat()
 	.filter(uniqueFilter)
 	.map((item: string) => {
 		return { label: item, value: item };
@@ -123,7 +124,8 @@ const personsFilter = computed(() =>
 	simpleItems.value
 		.filter((item) => {
 			if (!params.value.dataTypes.includes(item.dataType)) return false;
-			if (persons.value.length > 0) return persons.value.includes(item.person.name);
+			if (persons.value.length > 0)
+				return item.person.forEach((p) => persons.value.includes(p.name));
 			else if (places.value.length > 0) {
 				const found = places.value.map((place) => {
 					const p = place.split(":");
@@ -134,10 +136,16 @@ const personsFilter = computed(() =>
 				});
 				if (!found.includes(true)) return false;
 			}
-			if (sex.value.length > 0 && !sex.value.includes(item.person.sex)) return false;
-			return !(
-				age.value[0]! > parseInt(item.person.age) || age.value[1]! < parseInt(item.person.age)
-			);
+			if (sex.value.length > 0) {
+				if (
+					// If none of the participants are of the given sex
+					!item.person.map((p) => sex.value.includes(p.sex)).includes(true)
+				)
+					return false;
+			}
+			return item.person
+				.map((p) => age.value[0]! > parseInt(p.age) && age.value[1]! < parseInt(p.age))
+				.includes(true);
 		})
 		.map((item) => item.id),
 );

--- a/components/explore-samples-window-content.vue
+++ b/components/explore-samples-window-content.vue
@@ -9,7 +9,6 @@ const props = defineProps<Props>();
 const { params } = toRefs(props);
 const content: Ref<HTMLElement | undefined> = ref();
 const tooltip: Ref<HTMLElement | null> = ref(null);
-console.log(params);
 const { simpleItems } = useTEIHeaders();
 
 const filters: Array<"region" | "settlement"> = ["region", "settlement"];

--- a/components/explore-samples-window-content.vue
+++ b/components/explore-samples-window-content.vue
@@ -9,7 +9,7 @@ const props = defineProps<Props>();
 const { params } = toRefs(props);
 const content: Ref<HTMLElement | undefined> = ref();
 const tooltip: Ref<HTMLElement | null> = ref(null);
-
+console.log(params);
 const { simpleItems } = useTEIHeaders();
 
 const filters: Array<"region" | "settlement"> = ["region", "settlement"];
@@ -28,14 +28,14 @@ const ids = computed(() => {
 				})
 				.filter((item) => {
 					if (params.value.person) {
-						return params.value.person === item.person.name;
+						return item.person.map((p) => p.name).includes(params.value.person);
 					} else return true;
 				})
 				.map((item) => item.id)
 				.join(",");
 });
 
-const features: Ref<Array<string>> = ref([]);
+const features: Ref<Array<string>> = ref(params.value.features?.split(",") ?? []);
 const page: Ref<number> = ref(1);
 
 watch(params, (value) => {

--- a/components/profile-window-content.vue
+++ b/components/profile-window-content.vue
@@ -43,6 +43,7 @@ watch(content, () => {
 
 <style>
 /* stylelint-disable selector-class-pattern */
+/* stylelint-disable selector-type-no-unknown */
 
 .profileHeader img,
 .figure img {
@@ -50,11 +51,11 @@ watch(content, () => {
 }
 
 .tbProfile {
-	@apply border border-solid border-[#59533c];
+	@apply border border-solid border-[#59533c] mt-0;
 }
 
 .tdHead {
-	@apply align-top w-[150px] pr-[5px] border-dotted border-primary border-b bg-primary text-on-primary text-right break-words;
+	@apply align-top !w-[150px] pr-[5px] border-dotted border-primary border-b bg-primary text-on-primary text-right break-words;
 }
 
 .tdProfileTableRight {
@@ -102,11 +103,19 @@ a:hover {
 }
 
 .pNorm {
-	@apply mb-[10px];
+	@apply mb-4;
+}
+
+gallery + .pNorm {
+	@apply my-6;
+}
+
+.pNorm:has(+ gallery) {
+	@apply mb-6;
 }
 
 .imgCaption {
-	@apply pb-2 italic text-xs text-center;
+	@apply p-2 italic text-[0.85rem] text-center;
 }
 
 .h3ProfileTypology {
@@ -125,6 +134,11 @@ a:hover {
 	@apply text-white;
 
 	height: 450px;
+}
+
+.pFigure,
+.lg-container {
+	@apply my-4;
 }
 
 .pFigure.fig-col-3 {

--- a/components/ui/tags-select.vue
+++ b/components/ui/tags-select.vue
@@ -31,8 +31,8 @@ interface Props {
 
 const props = defineProps<Props>();
 const { options, placeholder, filterFunction } = toRefs(props);
-const searchTerm = ref("");
 const model = defineModel<Array<string>>();
+const searchTerm = defineModel<string>("searchTerm");
 const open = ref(false);
 watch(
 	model,

--- a/composables/use-data-words.ts
+++ b/composables/use-data-words.ts
@@ -4,11 +4,11 @@ import type { DataTypesEnum } from "@/types/global";
 
 interface DataWordParams {
 	dataType: string;
+	query: Ref<string>;
 }
 
 export function useDataWords(params: DataWordParams, options?: { enabled?: boolean }) {
 	const api = useApiClient();
-
 	return useQuery({
 		enabled: options?.enabled,
 		queryKey: ["get-data-words", params] as const,
@@ -16,6 +16,7 @@ export function useDataWords(params: DataWordParams, options?: { enabled?: boole
 			const response = await api.vicav.getDataWords(
 				{
 					type: dataTypes[params.dataType as DataTypesEnum].collection.replace("vicav_", ""),
+					query: params.query.value,
 				},
 				{
 					headers: { accept: "application/json" },

--- a/types/teiCorpus.d.ts
+++ b/types/teiCorpus.d.ts
@@ -1,6 +1,11 @@
 /* eslint-disable @typescript-eslint/consistent-type-definitions */
 import type { JsonValue } from "type-fest";
 
+type simplePerson = {
+	name: string;
+	sex: string;
+	age: string;
+};
 export type simpleTEIMetadata = {
 	id: string;
 	label: string;
@@ -14,11 +19,7 @@ export type simpleTEIMetadata = {
 		country: string;
 		region: string;
 	};
-	person: {
-		name: string;
-		sex: string;
-		age: string;
-	};
+	person: Array<simplePerson>;
 	"@hasTEIw": string;
 	teiHeader: TeiHeader;
 };

--- a/utils/groupByFourLevels.ts
+++ b/utils/groupByFourLevels.ts
@@ -17,9 +17,20 @@ export function getGroupedItems(
 	levelProperties: [string, string, string, string],
 	dataTypeProperty: string,
 	allowedDataTypes: Array<string>,
-	sortProperty: string,
+	sortProperty: string | ((a: JsonObject, b: JsonObject) => number),
 	filterListBy?: { key: string; value: string },
 ) {
+	const sortFunction =
+		typeof sortProperty === "string"
+			? (a: JsonObject, b: JsonObject) => {
+					const aLabel = deepGet(a, sortProperty, ""),
+						bLabel = deepGet(b, sortProperty, "");
+					if (aLabel && bLabel && typeof aLabel === "string" && typeof bLabel === "string") {
+						return aLabel.localeCompare(bLabel);
+					}
+					return 0;
+				}
+			: sortProperty;
 	// Group by L1
 	const collectedItems = items
 		.filter((item) => {
@@ -30,14 +41,7 @@ export function getGroupedItems(
 			if (typeof dataType !== "string") return false;
 			return isAllowedDataType && filterByIsTrue;
 		})
-		.sort((a, b) => {
-			const aLabel = deepGet(a, sortProperty, ""),
-				bLabel = deepGet(b, sortProperty, "");
-			if (aLabel && bLabel && typeof aLabel === "string" && typeof bLabel === "string") {
-				return aLabel.localeCompare(bLabel);
-			}
-			return 0;
-		});
+		.sort(sortFunction);
 
 	const grouped = Object.groupBy(collectedItems, (item: JsonObject) => {
 		const L1 = deepGet(item, levelProperties[0], "");
@@ -80,14 +84,7 @@ export function getGroupedItems(
 				for (const L4 in (grouped as groupedByL1)[L1]![L2]![L3]!) {
 					(grouped as groupedByL1)[L1]![L2]![L3]![L4] = (grouped as groupedByL1)[L1]![L2]![L3]![
 						L4
-					]!.sort((a, b) => {
-						const aLabel = deepGet(a, sortProperty, ""),
-							bLabel = deepGet(b, sortProperty, "");
-						if (aLabel && bLabel && typeof aLabel === "string" && typeof bLabel === "string") {
-							return aLabel.localeCompare(bLabel);
-						}
-						return 0;
-					});
+					]!.sort(sortFunction);
 				}
 			}
 		}


### PR DESCRIPTION
* Add diacritics-insensitive simple word search to Corpus query form
* Allow for more granular sort (ie. by speaker number) of lists
* Fix layout issues on Profile
* Move word search autocomplete logic to back-end to improve performance
* Add number of results
* Handle array of persons as simpleteimetadata.person field

Needs https://github.com/acdh-oeaw/vicav-app-api/pull/28 to funciton properly