### PR TITLE
fix: adjust for chg in teiHeader structure

### DIFF
--- a/components/data-table/data-table-filter-tei-headers.vue
+++ b/components/data-table/data-table-filter-tei-headers.vue
@@ -118,16 +118,18 @@ watch(
 				</Select>
 			</div>
 			<div class="flex items-center space-x-2">
-				<p id="settlement" class="whitespace-nowrap text-sm font-medium">Place:</p>
-				<Input
+				<label class="whitespace-nowrap text-sm font-medium" for="place">Place:</label>
+				<input
+					id="place"
 					class="h-8 w-32 rounded-md border border-input"
 					:value="settlementFilter?.value"
 					@change="setSettlementFilter"
 				/>
 			</div>
 			<div class="flex items-center space-x-2">
-				<p id="settlement" class="whitespace-nowrap text-sm font-medium">Region:</p>
-				<Input
+				<label class="whitespace-nowrap text-sm font-medium" for="region">Region:</label>
+				<input
+					id="region"
 					class="h-8 w-32 rounded-md border border-input"
 					:value="regionFilter?.value"
 					@change="setRegionFilter"
@@ -136,8 +138,9 @@ watch(
 		</div>
 		<div class="flex items-center space-x-2">
 			<div class="flex items-center space-x-2">
-				<p id="name" class="whitespace-nowrap text-sm font-medium">Speaker:</p>
-				<Input
+				<label class="whitespace-nowrap text-sm font-medium" for="speaker">Speaker:</label>
+				<input
+					id="speaker"
 					class="h-8 w-32 rounded-md border border-input"
 					:value="speakerFilter?.value"
 					@change="setSpeakerFilter"

--- a/components/ui/sex-filter.vue
+++ b/components/ui/sex-filter.vue
@@ -36,9 +36,9 @@ const filterUpdated = function () {
 			for="sex-male"
 		>
 			<CheckboxRoot
+				id="sex-male"
 				v-model:checked="male"
 				class="flex size-[20px] appearance-none items-center justify-center rounded-[4px] bg-white shadow-[0_2px_2px] shadow-gray-300 outline-hidden focus-within:shadow-[0_0_0_2px_gray]"
-				if="sex-male"
 				@update:checked="filterUpdated"
 			>
 				<CheckboxIndicator class="flex size-full items-center justify-center rounded bg-white">

--- a/composables/use-tei-headers.ts
+++ b/composables/use-tei-headers.ts
@@ -277,8 +277,8 @@ const extractMetadata = function (
 
 	template.person = extractPersons(item, corpusMetadata);
 	if (template.dataType === "CorpusText" && corpusMetadata) {
-		const categoryId = item.teiHeader.profileDesc?.textClass?.catRef
-			? item.teiHeader.profileDesc.textClass.catRef["@target"]
+		const categoryId = item.teiHeader.profileDesc?.textClass?.catRefs
+			? item.teiHeader.profileDesc.textClass.catRefs[0]!["@target"]
 			: "";
 
 		const mergedTaxonomies: Taxonomy = {
@@ -291,7 +291,6 @@ const extractMetadata = function (
 		const category = mergedTaxonomies.categories.find(
 			(cat) => cat["@id"] === categoryId?.replace("corpus:", ""),
 		);
-
 		if (category?.catDesc.name) {
 			template.category = category.catDesc.name.$;
 		} else if (category?.catDesc.$) {

--- a/types/teiCorpus.d.ts
+++ b/types/teiCorpus.d.ts
@@ -423,7 +423,7 @@ export type PlaceName = {
 };
 
 export type TextClass = {
-	catRef?: TeiTypedTarget;
+	catRefs?: Array<TeiTypedTarget>;
 };
 
 export type RevisionDesc = {


### PR DESCRIPTION
@dasch124 @simar0at this resolves #281  

the underlying reason for the bug was that `teiHeader.profileDesc.textClass.catRef` is renamed `teiHeader.profileDesc.textClass.catRefs` and now of type `array`

please check if
* this change is intended
* how many items the array may contain (the current fix assumes there is only one item)